### PR TITLE
Encrypt the contacts and invoices data completely.

### DIFF
--- a/app/containers/Settings.jsx
+++ b/app/containers/Settings.jsx
@@ -32,6 +32,10 @@ import {
   getSavedSettings,
 } from '../reducers/SettingsReducer';
 
+import {
+  getSecretKey
+} from '../reducers/exportImportReducer'
+
 // Actions
 import * as SettingsActions from '../actions/settings';
 import * as ExportImportActions from '../actions/exportImport';
@@ -82,7 +86,8 @@ class Settings extends Component {
   }
 
   handleFileUpload(filePath) {
-    parseImportFile(filePath, (err, fileData) => {
+    const { secretKey } = this.props
+    parseImportFile(filePath, secretKey, (err, fileData) => {
       if (err) {
         return;
       }
@@ -182,6 +187,7 @@ Settings.propTypes = {
   }),
   currentSettings: PropTypes.object.isRequired,
   savedSettings: PropTypes.object.isRequired,
+  secretKey: PropTypes.string.isRequired,
 };
 
 // Map State & Dispatch to Props & Export
@@ -193,6 +199,7 @@ const mapDispatchToProps = dispatch => ({
 const mapStateToProps = state => ({
   currentSettings: getCurrentSettings(state),
   savedSettings: getSavedSettings(state),
+  secretKey: getSecretKey(state)
 });
 
 export default compose(

--- a/app/helpers/encryption.js
+++ b/app/helpers/encryption.js
@@ -56,6 +56,13 @@ function decrypt({ docs, secretKey }) {
     return contentDecrypted;
 }
 
+function decryptDataToImport( { data , secretKey }) {
+    const contentDecrypted = ipc.sendSync('decrypt-data', { content: data, secretKey })
+    if(!contentDecrypted) return null;
+
+    return contentDecrypted;
+}
+
 function getSettings() {
     return ipc.sendSync('encryption-get-settings')
 }
@@ -64,4 +71,4 @@ function setSettings(iv, salt, validation) {
     return ipc.sendSync('encryption-set-settings', { iv, salt, validation })
 }
 
-module.exports = { encrypt, decrypt, getSettings, setSettings }
+module.exports = { encrypt, decrypt, decryptDataToImport, getSettings, setSettings }

--- a/app/helpers/importFile.js
+++ b/app/helpers/importFile.js
@@ -1,11 +1,18 @@
 const fs = require('fs')
+const { decryptDataToImport } =  require('./encryption')
 
-function parseImportFile(filePath, callback) {
+
+function parseImportFile(filePath, secretKey, callback) {
     try {
-        const data = fs.readFileSync(filePath);
-        const parsedData = JSON.parse(data)
+        const fileData = fs.readFileSync(filePath);
+        
+        const parsedData = JSON.parse(fileData)
 
-        const { contacts, invoices } = parsedData;
+        const { data, settings } = parsedData;
+
+        const dataDecrypted = decryptDataToImport({ data, secretKey });
+
+        const { contacts, invoices } = dataDecrypted;
 
         const newContacts = contacts.map(doc => {
             delete doc._rev;
@@ -17,9 +24,7 @@ function parseImportFile(filePath, callback) {
             return doc
         })
 
-        Object.assign(parsedData, { contacts: newContacts, invoices: newInvoices })
-
-        callback(null, parsedData);
+        callback(null, { contacts: newContacts, invoices: newInvoices, settings});
         return;
     } catch (error) {
         callback(error, null);

--- a/app/reducers/exportImportReducer.jsx
+++ b/app/reducers/exportImportReducer.jsx
@@ -1,4 +1,5 @@
 import { handleActions, combineActions } from 'redux-actions';
+import { createSelector } from 'reselect';
 import * as Actions from '../actions/exportImport';
 
 const exportImportReducer = handleActions(
@@ -12,3 +13,10 @@ const exportImportReducer = handleActions(
 );
 
 export default exportImportReducer;
+
+const getLoginState = state => state.login
+
+export const getSecretKey = createSelector(
+  getLoginState,
+  login => login.secretKey
+)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "invoncify",
   "homepage": "https://invoncify.andresmorelos.me",
   "productName": "Invoncify",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "GPL-3.0",
   "description": "Flexible invoicing desktop app with beautiful & customizable templates",
   "author": {


### PR DESCRIPTION
The export schema changes to:

```json
{
  "data": "CONTENT_ENCRYPTED (Contacts, Invoices, ANY Future Content)",
  "settings" : {
        "iv": "IV",
        "salt": "SALT",
        "validation": "VALIDATION"
       }
}
```

with this new schema, an attacker will not know how many contacts, invoices the user has